### PR TITLE
Added `computeKey`, more tests & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ import {WarpFactory} from 'warp-contracts';
 
 const warp = WarpFactory.forMainnet();
 const args: HollowDbSdkArgs = {
-  jwk,
-  contractTxId,
-  cacheType,
-  warp,
+  jwk, // read a wallet
+  contractTxId, // contract to connect to
+  cacheType, // lmdb or redis
+  warp, // mainnet, testnet, or local
 };
 const sdk = new SDK(args);
 const admin = new Admin(args);
@@ -222,7 +222,24 @@ const proof = fullProof.proof;
 await sdk.update(key, newValue, proof);
 ```
 
-You might notice that the `key` is being read from the public signals. This is because we need to hash the preimage with Poseidon hash to make this request. If you do not have the key in the first place, you can use a package such as [Poseidon Lite](https://www.npmjs.com/package/poseidon-lite) to easily find the hash of your preimage.
+### Proving in Browser
+
+Since proof generation is using SnarkJS in the background, you might need to add some settings to your web app to run it. See the [SnarkJS docs](https://github.com/iden3/snarkjs#in-the-browser) for this. For example, you could have an option like the following within your NextJS config file:
+
+```js
+webpack: (config, { isServer }) => {
+  if (!isServer) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      fs: false, // added for SnarkJS
+      readline: false, // added for SnarkJS
+    };
+  }
+  // added to run WASM for SnarkJS
+  config.experiments = { asyncWebAssembly: true };
+  return config;
+},
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -160,25 +160,7 @@ We use such an approach in our [HollowDB gRPC server](https://github.com/firstba
 
 HollowDB is a **key-value** database where each **key** in the database is the [Poseidon hash](https://www.poseidon-hash.info/) of some preimage. The client provides a "preimage knowledge proof" to update or remove a value at that key. Additional constraints on the current value and next value to be written are also given to the proof as a preventive measure against replay attacks and middle-man attacks.
 
-```mermaid
-flowchart LR
-  pi[public\ninputs]
-  i0(preimage) --> si[secret\ninputs]
-  i1(curHash) --> si
-  i2(nextHash) --> si
-
-  subgraph hollow authz circuit
-  si --> ha[circuit]
-  pi --> ha
-
-  ha --> proof
-  ha --> o[outputs]
-  end
-
-  o --> o0(curHash)
-  o --> o1(nextHash)
-  o --> o2(key)
-```
+[![hollow-authz](https://mermaid.ink/img/pako:eNpdkLtuwzAMRX9F4OQACZBk9NCpQ4dO7WhlYCQ6ImI9oAfaNMi_V7bT1O0mnnsgXPIKymuCFvrBfyiDMYvXN-mECNyFchxYSenYhZLTYcS8bUIktniildhsnkTiLpGKlP95u0aV-ILJ_GgT3TeOPvNfPAapHE8RgxHGD7WIwJLNl1AcVeE8CTz5Brs7PMwl73T-xeA0huh9v5h950t-NCOnZ9vP4fZRdAF3vz0XdN-c6bKCNViKFlnXs13HWEI2ZElCW58a41mCdLfq1TX8-8UpaHMstIYSNGZ6ZqzLWmh7HBLdvgG7u38h?type=png)](https://mermaid.live/edit#pako:eNpdkLtuwzAMRX9F4OQACZBk9NCpQ4dO7WhlYCQ6ImI9oAfaNMi_V7bT1O0mnnsgXPIKymuCFvrBfyiDMYvXN-mECNyFchxYSenYhZLTYcS8bUIktniildhsnkTiLpGKlP95u0aV-ILJ_GgT3TeOPvNfPAapHE8RgxHGD7WIwJLNl1AcVeE8CTz5Brs7PMwl73T-xeA0huh9v5h950t-NCOnZ9vP4fZRdAF3vz0XdN-c6bKCNViKFlnXs13HWEI2ZElCW58a41mCdLfq1TX8-8UpaHMstIYSNGZ6ZqzLWmh7HBLdvgG7u38h)
 
 As shown above, all inputs are secret for HollowDB prover, although `curHash` and `nextHash` are immediately provided as an output.
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,12 +1,12 @@
-const {SDK} = require('hollowdb');
+const {SDK, computeKey} = require('hollowdb');
 const {WarpFactory} = require('warp-contracts');
-const {contractTxId, jwk} = require('./utils/config');
+const {contractTxId, jwk, wasmPath, proverKeyPath} = require('./utils/config');
 
 async function main() {
-  //create a warp instance for feeding into hollowdb
+  // create a warp instance for hollowdb
   const warp = WarpFactory.forMainnet();
 
-  //create a hollowdb instance
+  // create a hollowdb instance
   const db = new SDK({
     warp: warp,
     contractTxId: contractTxId,
@@ -14,28 +14,23 @@ async function main() {
     cacheType: 'lmdb',
   });
 
-  //create a key preferably using some sort of hash function like sha256 to avoid collisions.
-  //hollowdb does not allow duplicate keys
-  const key = 'your-low-collision-key';
+  // your key, as a hash of your secret
+  const key = computeKey('your-secret');
 
-  //payload can be anything you want to store, but it must not exceed 2kb
-  //if you need to store more than 2kb, you can use bundlr to store the data on arweave and store the txid in hollowdb
+  // value can be anything you want to store, but it must not exceed 2kb
+  // if you need to store more than 2kb, you can use bundlr to store the data on arweave and store the txid in hollowdb
   const payload = {
     name: 'John Doe',
     age: 21,
     address: '123 Main St',
   };
 
-  //put the key and payload into hollowdb
+  // put the key and payload into hollowdb
   await db.put(key, payload);
 
-  //get the payload from hollowdb
+  // get the payload from hollowdb
   const result = await db.get(key);
-
-  //print the result
-  console.log('Get Result: ', result);
-
-  //done!
+  console.log(result);
 }
 
 main();

--- a/examples/utils/bundlr.js
+++ b/examples/utils/bundlr.js
@@ -1,6 +1,6 @@
 const Bundlr = require('@bundlr-network/client');
 
-//for more information on bundlr, visit https://bundlr.network
+// for more information on bundlr, visit https://bundlr.network
 async function upload(jwk, payload) {
   const bundlr = new Bundlr.default('http://node1.bundlr.network', 'arweave', jwk);
 
@@ -17,8 +17,8 @@ async function upload(jwk, payload) {
   await transaction.sign();
   const txID = transaction.id;
 
-  //you can choose to not await this if you want to upload in the background
-  //but if the upload fails, you will not be able to get the data from the txid
+  // you can choose to not await this if you want to upload in the background
+  // but if the upload fails, you will not be able to get the data from the txid
   await transaction.upload();
   return txID;
 }

--- a/examples/utils/config.js
+++ b/examples/utils/config.js
@@ -1,7 +1,7 @@
-//contract tx id
+// contract tx id
 const contractTxId = '...';
 
-//arweave wallet
+// arweave wallet
 const jwk = {
   kty: '...',
   n: '...',
@@ -14,5 +14,12 @@ const jwk = {
   qi: '...',
 };
 
+// path to WASM circuit and prover key
+// could be stored under `public` folder for a web app
+const wasmPath = 'path-to-wasm-circuit';
+const proverKeyPath = 'path-to-prover-key';
+
 exports.contractTxId = contractTxId;
 exports.jwk = jwk;
+exports.wasmPath = wasmPath;
+exports.proverKeyPath = proverKeyPath;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,19 @@
     "Faruk Can Özkan <farukcan@firstbatch.xyz>",
     "Erhan Tezcan <erhan@firstbatch.xyz>"
   ],
+  "keywords": [
+    "key-value store",
+    "storage",
+    "database",
+    "zksnark",
+    "blockchain",
+    "smart-contracts",
+    "arweave",
+    "smartweave",
+    "circom",
+    "warp-contracts",
+    "zero-knowledge"
+  ],
   "cjs": "lib/index.cjs",
   "mjs": "lib/index.mjs",
   "exports": {
@@ -67,15 +80,16 @@
     "yalc:publish": "yarn build && yalc publish --push"
   },
   "dependencies": {
+    "@ethersproject/sha2": "^5.7.0",
+    "poseidon-lite": "^0.1.0",
     "redis": "^4.6.4",
+    "snarkjs": "^0.6.1",
     "warp-contracts": "^1.2.56",
     "warp-contracts-lmdb": "^1.1.9",
     "warp-contracts-plugin-deploy": "^1.0.0",
     "warp-contracts-plugin-ethers": "^1.0.7",
     "warp-contracts-plugin-snarkjs": "^0.1.3",
-    "warp-contracts-redis": "^0.1.2",
-    "@ethersproject/sha2": "^5.7.0",
-    "snarkjs": "^0.6.1"
+    "warp-contracts-redis": "^0.1.2"
   },
   "devDependencies": {
     "@parcel/packager-ts": "2.8.3",
@@ -95,7 +109,6 @@
     "gts": "^3.1.1",
     "jest": "^29.4.3",
     "parcel": "^2.8.3",
-    "poseidon-lite": "^0.0.2",
     "prettier": "2.8.3",
     "replace-in-file": "^6.3.5",
     "rimraf": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "blockchain",
     "smart-contracts",
     "arweave",
+    "anonymous",
     "smartweave",
     "circom",
     "warp-contracts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {SDK, Admin} from './sdk';
+export {SDK, Admin, computeKey} from './sdk';
 export {Prover} from './prover';
 export type {HollowDbSdkArgs, CacheType} from './sdk';

--- a/src/sdk/admin/index.ts
+++ b/src/sdk/admin/index.ts
@@ -115,7 +115,7 @@ export class Admin extends Base {
    * @param owner wallet to deploy the contract
    * @param initialState the initial HollowDB state; owner will be overwritten
    * @param contractSource source code of the contract, as a string
-   * @param warp optional warp instance, defaults to mainnet
+   * @param warp warp instance
    * @returns transaction ids
    */
   static async deploy(
@@ -155,22 +155,26 @@ export class Admin extends Base {
   /**
    * Utility function to evolve the HollowDB contract.
    * @param owner wallet to deploy the new contract
-   * @param contractSource source code of the contract, as a string
-   * @param contractTxId existing contract source transaction id
-   * @param warp optional warp instance, defaults to mainnet
+   * @param contractSource source code of the new contract, as a string
+   * @param contractTxId contract transaction id of the old contract
+   * @param warp warp instance
    * @returns transaction ids
    */
   static async evolve(
     owner: JWKInterface,
     contractSource: string,
     contractTxId: string,
-    warp: Warp
+    warp: Warp,
+    disableBundling = false
   ): Promise<{contractTxId: string; srcTxId: string}> {
     // connect to the contract that we want to evolve
     const contract = warp.contract(contractTxId).connect(owner);
 
     // create a new source
-    const newSource = await warp.createSource({src: contractSource}, new ArweaveSigner(owner));
+    const newSource = await warp.createSource(
+      {src: contractSource},
+      disableBundling ? owner : new ArweaveSigner(owner)
+    );
 
     // save contract source
     const newSrcTxId = await warp.saveSource(newSource);

--- a/src/sdk/base/index.ts
+++ b/src/sdk/base/index.ts
@@ -101,7 +101,7 @@ export class Base {
     // SnarkJS extension is required for proof verification
     warp = warp.use(new SnarkjsExtension());
 
-    // Ethers extension is required for SHA256
+    // Ethers extension is required for hashing
     warp = warp.use(new EthersExtension());
 
     // instantiate HollowDB

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,3 +1,13 @@
+import {poseidon1} from 'poseidon-lite';
 export {SDK} from './sdk';
 export {Admin} from './admin';
 export type {HollowDbSdkArgs, CacheType} from './types';
+
+/**
+ * Compute the key that only you can know.
+ * @param preimage your secret, the preimage of the key
+ * @returns key, as the Poseidon hash of your secret
+ */
+export function computeKey(preimage: bigint): string {
+  return poseidon1([preimage]).toString();
+}

--- a/tests/constants/index.ts
+++ b/tests/constants/index.ts
@@ -1,0 +1,13 @@
+const constants = {
+  // port to run
+  ARWEAVE_PORT: 3169,
+  // arbitrarily long timeout for the test
+  JEST_TIMEOUT_MS: 30000,
+  // to generate proofs
+  WASM_PATH: './circuits/hollow-authz/hollow-authz.wasm',
+  PROVERKEY_PATH: './circuits/hollow-authz/prover_key.zkey',
+  // to verify proofs (given to the contract)
+  VERIFICATIONKEY_PATH: './circuits/hollow-authz/verification_key.json',
+};
+
+export default constants as Readonly<typeof constants>;

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -1,0 +1,80 @@
+import ArLocal from 'arlocal';
+import {JWKInterface, LoggerFactory, Warp, WarpFactory} from 'warp-contracts';
+import {DeployPlugin} from 'warp-contracts-plugin-deploy';
+import dummyContractSource from './res/dummyContract';
+import initialState from '../common/initialState';
+import fs from 'fs';
+import path from 'path';
+import {Admin, SDK} from '../src';
+
+// arbitrarily long timeout
+jest.setTimeout(30000);
+
+const ARWEAVE_PORT = 3169;
+
+describe('hollowdb evolve', () => {
+  let arlocal: ArLocal;
+  let contractSource: string;
+  let contractTxId: string;
+  let newContractSource: string;
+  let warp: Warp;
+
+  let ownerJWK: JWKInterface;
+
+  beforeAll(async () => {
+    arlocal = new ArLocal(ARWEAVE_PORT, false);
+    await arlocal.start();
+
+    LoggerFactory.INST.logLevel('error');
+
+    contractSource = fs.readFileSync(path.join(__dirname, '../build/hollowDB/contract.js'), 'utf8');
+    newContractSource = dummyContractSource;
+
+    // setup warp factory for local arweave
+    warp = WarpFactory.forLocal(ARWEAVE_PORT).use(new DeployPlugin());
+
+    // get accounts
+    const ownerWallet = await warp.generateWallet();
+    ownerJWK = ownerWallet.jwk;
+
+    // deploy contract
+    const {contractTxId: hollowDBTxId} = await Admin.deploy(
+      ownerJWK,
+      initialState,
+      contractSource,
+      warp,
+      true // bundling is disabled during testing
+    );
+
+    const contractTx = await warp.arweave.transactions.get(hollowDBTxId);
+    expect(contractTx).not.toBeNull();
+
+    contractTxId = hollowDBTxId;
+  });
+
+  it('should evolve contract', async () => {
+    // evolve
+    const {contractTxId: newContractTxId, srcTxId: newSrcTxId} = await Admin.evolve(
+      ownerJWK,
+      newContractSource,
+      contractTxId,
+      warp,
+      true
+    );
+
+    // create new SDK
+    const ownerSDK = new SDK({
+      jwk: ownerJWK,
+      contractTxId: newContractTxId,
+      cacheType: 'lmdb',
+      warp,
+    });
+
+    // state should have the new source id within its "evolve" field
+    const {cachedValue} = await ownerSDK.readState();
+    expect(cachedValue.state.evolve).toEqual(newSrcTxId);
+
+    // calling a non-existent function in the new contract should give error
+    await expect(ownerSDK.put('1234', '1234')).rejects.toThrow('Contract Error [put]: Unknown function: put');
+  });
+});

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -6,11 +6,10 @@ import initialState from '../common/initialState';
 import fs from 'fs';
 import path from 'path';
 import {Admin, SDK} from '../src';
+import constants from './constants';
 
 // arbitrarily long timeout
-jest.setTimeout(30000);
-
-const ARWEAVE_PORT = 3169;
+jest.setTimeout(constants.JEST_TIMEOUT_MS);
 
 describe('hollowdb evolve', () => {
   let arlocal: ArLocal;
@@ -22,7 +21,11 @@ describe('hollowdb evolve', () => {
   let ownerJWK: JWKInterface;
 
   beforeAll(async () => {
-    arlocal = new ArLocal(ARWEAVE_PORT, false);
+    /**
+     * TODO: we are creating a new arlocal instance here, otherwise it clashes with the other one
+     * we may use fixtures as a fix here
+     */
+    arlocal = new ArLocal(constants.ARWEAVE_PORT + 1, false);
     await arlocal.start();
 
     LoggerFactory.INST.logLevel('error');
@@ -31,7 +34,7 @@ describe('hollowdb evolve', () => {
     newContractSource = dummyContractSource;
 
     // setup warp factory for local arweave
-    warp = WarpFactory.forLocal(ARWEAVE_PORT).use(new DeployPlugin());
+    warp = WarpFactory.forLocal(constants.ARWEAVE_PORT + 1).use(new DeployPlugin());
 
     // get accounts
     const ownerWallet = await warp.generateWallet();

--- a/tests/hollow-authz.test.ts
+++ b/tests/hollow-authz.test.ts
@@ -1,5 +1,5 @@
 import {readFileSync} from 'fs';
-import {Prover} from '../src';
+import {Prover, computeKey} from '../src';
 const snarkjs = require('snarkjs');
 
 // WASM and prover key for generating proofs
@@ -40,6 +40,9 @@ describe('hollow-authz circuit', () => {
     correctCurValueHash = fullProof.publicSignals[0];
     correctNewValueHash = fullProof.publicSignals[1];
     correctKey = fullProof.publicSignals[2];
+
+    // computeKey should find the same result
+    expect(correctKey).toEqual(computeKey(preimage));
   });
 
   it('should verify proof', async () => {

--- a/tests/hollow-authz.test.ts
+++ b/tests/hollow-authz.test.ts
@@ -1,13 +1,7 @@
 import {readFileSync} from 'fs';
 import {Prover, computeKey} from '../src';
+import constants from './constants';
 const snarkjs = require('snarkjs');
-
-// WASM and prover key for generating proofs
-const WASM_PATH = './circuits/hollow-authz/hollow-authz.wasm';
-const PROVERKEY_PATH = './circuits/hollow-authz/prover_key.zkey';
-
-// verification key to verify the proofs
-const VERIFICATIONKEY_PATH = './circuits/hollow-authz/verification_key.json';
 
 const preimage = BigInt(1122334455);
 const curValue = {
@@ -31,8 +25,8 @@ describe('hollow-authz circuit', () => {
 
   beforeAll(async () => {
     // prepare prover and verification key
-    prover = new Prover(WASM_PATH, PROVERKEY_PATH);
-    verificationKey = JSON.parse(readFileSync(VERIFICATIONKEY_PATH).toString());
+    prover = new Prover(constants.WASM_PATH, constants.PROVERKEY_PATH);
+    verificationKey = JSON.parse(readFileSync(constants.VERIFICATIONKEY_PATH).toString());
 
     // generate a proof
     const fullProof = await prover.generateProof(preimage, curValue, newValue);

--- a/tests/hollowdb.test.ts
+++ b/tests/hollowdb.test.ts
@@ -8,13 +8,9 @@ import {SDK, Admin, Prover, computeKey} from '../src';
 import type {CacheType} from '../src/sdk/types';
 import {randomBytes} from 'crypto';
 import {prepareSDKs} from './utils';
+import constants from './constants';
 
-// WASM and prover key for generating proofs
-const WASM_PATH = './circuits/hollow-authz/hollow-authz.wasm';
-const PROVERKEY_PATH = './circuits/hollow-authz/prover_key.zkey';
-
-// arbitrarily long timeout
-jest.setTimeout(30000);
+jest.setTimeout(constants.JEST_TIMEOUT_MS);
 
 enum PublicSignal {
   CurValueHash = 0,
@@ -22,22 +18,20 @@ enum PublicSignal {
   Key = 2,
 }
 
-const ARWEAVE_PORT = 3169;
-
 describe('hollowdb', () => {
   let arlocal: ArLocal;
   let contractSource: string;
   let prover: Prover;
 
   beforeAll(async () => {
-    arlocal = new ArLocal(ARWEAVE_PORT, false);
+    arlocal = new ArLocal(constants.ARWEAVE_PORT, false);
     await arlocal.start();
 
     LoggerFactory.INST.logLevel('error');
 
     contractSource = fs.readFileSync(path.join(__dirname, '../build/hollowDB/contract.js'), 'utf8');
 
-    prover = new Prover(WASM_PATH, PROVERKEY_PATH);
+    prover = new Prover(constants.WASM_PATH, constants.PROVERKEY_PATH);
   });
 
   describe.each<CacheType>(['lmdb', 'redis'])('using %s cache, proofs enabled', cacheType => {
@@ -53,7 +47,7 @@ describe('hollowdb', () => {
 
     beforeAll(async () => {
       // setup warp factory for local arweave
-      warp = WarpFactory.forLocal(ARWEAVE_PORT).use(new DeployPlugin());
+      warp = WarpFactory.forLocal(constants.ARWEAVE_PORT).use(new DeployPlugin());
 
       // get accounts
       const ownerWallet = await warp.generateWallet();

--- a/tests/hollowdb.test.ts
+++ b/tests/hollowdb.test.ts
@@ -4,9 +4,8 @@ import {DeployPlugin} from 'warp-contracts-plugin-deploy';
 import initialState from '../common/initialState';
 import fs from 'fs';
 import path from 'path';
-import {SDK, Admin, Prover} from '../src';
+import {SDK, Admin, Prover, computeKey} from '../src';
 import type {CacheType} from '../src/sdk/types';
-import poseidon from 'poseidon-lite';
 import {randomBytes} from 'crypto';
 import {prepareSDKs} from './utils';
 
@@ -48,7 +47,7 @@ describe('hollowdb', () => {
     let warp: Warp;
 
     const KEY_PREIMAGE = BigInt('0x' + randomBytes(10).toString('hex'));
-    const KEY = poseidon([KEY_PREIMAGE]).toString();
+    const KEY = computeKey(KEY_PREIMAGE);
     const VALUE_TX = randomBytes(10).toString('hex');
     const NEXT_VALUE_TX = randomBytes(10).toString('hex');
 
@@ -207,7 +206,7 @@ describe('hollowdb', () => {
 
     describe('tests with proofs disabled', () => {
       const KEY_PREIMAGE = BigInt('0x' + randomBytes(10).toString('hex'));
-      const KEY = poseidon([KEY_PREIMAGE]).toString();
+      const KEY = computeKey(KEY_PREIMAGE);
       const VALUE_TX = randomBytes(10).toString('hex');
       const NEXT_VALUE_TX = randomBytes(10).toString('hex');
 
@@ -243,7 +242,7 @@ describe('hollowdb', () => {
         let aliceAddress: string;
 
         const KEY_PREIMAGE = BigInt('0x' + randomBytes(10).toString('hex'));
-        const KEY = poseidon([KEY_PREIMAGE]).toString();
+        const KEY = computeKey(KEY_PREIMAGE);
         const VALUE_TX = randomBytes(10).toString('hex');
         const NEXT_VALUE_TX = randomBytes(10).toString('hex');
 

--- a/tests/res/dummyContract.ts
+++ b/tests/res/dummyContract.ts
@@ -1,0 +1,21 @@
+const dummyContractSource = `
+// contracts/hollowDB/actions/read/get.ts
+var get = async (state, action) => {
+  const {key} = action.input.data;
+  return {
+    result: await SmartWeave.kv.get(key),
+  };
+};
+
+// contracts/hollowDB/contract.ts
+var handle = (state, action) => {
+  switch (action.input.function) {
+    case 'get':
+      return get(state, action);
+    default:
+      throw new ContractError('Unknown function: ' + action.input.function);
+  }
+};
+`;
+
+export default dummyContractSource;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8388,10 +8388,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-poseidon-lite@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.0.2.tgz#dc1a7c57f9393a586c5c9efc21b72b77e2c1acb6"
-  integrity sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw==
+poseidon-lite@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.1.0.tgz#385f9c229e2e5325911e0cf5a70c623310ff4e34"
+  integrity sha512-aYKHQPpLaSrEOllS6MwGtch6xHViS0MlpwHiKOUI7h7geVsmg3FC13LzY8bpIndBRNNpOJM2j/9VtS6ZmALQNw==
 
 postcss-value-parser@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
- Added tests for evolve function
- Readme docs are updated for the latest version
- Small doc fixes in Admin and refactors in the test
- Added `computeKey` utility function to compute the key from a preimage, without generating a proof. We use `poseidon-lite` for this. We were also using it before, but now I have updated it to the latest version too.
- Added docs about using hollowdb with browser

If things are ok, we can merge this to master and have our v0.1.9