### PR TITLE
fixed `remove` via `KV.del`, updated Redis cache

### DIFF
--- a/contracts/hollowDB/actions/crud/remove.ts
+++ b/contracts/hollowDB/actions/crud/remove.ts
@@ -30,9 +30,7 @@ export const remove: HollowDBContractFunction<HollowDBRemove> = async (state, ac
     !state.isProofRequired ||
     (await verifyProof(proof, [valueToBigInt(dbValue), 0n, BigInt(key)], state.verificationKey))
   ) {
-    // TODO: we are not using `del` yet, as it may not completely remove every key in the cache
-    // there is `delete` function defined in SortKeyCache but it is not exported in KV yet.
-    await SmartWeave.kv.put(key, null);
+    await SmartWeave.kv.del(key);
   } else {
     throw errors.InvalidProofError(action.input.function);
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "poseidon-lite": "^0.1.0",
     "snarkjs": "^0.6.1",
     "warp-contracts-lmdb": "^1.1.10",
-    "warp-contracts-redis": "^0.2.0"
+    "warp-contracts-redis": "^0.3.0"
   },
   "devDependencies": {
     "@ethersproject/sha2": "^5.7.0",

--- a/tests/utils/cache.ts
+++ b/tests/utils/cache.ts
@@ -1,0 +1,114 @@
+import {CacheOptions, Warp, defaultCacheOptions} from 'warp-contracts';
+import {LmdbCache} from 'warp-contracts-lmdb';
+import {LmdbOptions} from 'warp-contracts-lmdb/lib/types/LmdbOptions';
+import {RedisCache, RedisOptions} from 'warp-contracts-redis';
+import constants from '../constants';
+import {globals} from '../../jest.config.cjs';
+import {Redis} from 'ioredis';
+
+export function overrideCache(
+  warp: Warp,
+  contractTxId: string,
+  cacheType: 'lmdb' | 'redis' | 'default',
+  useCache: {state?: boolean; contract?: boolean},
+  client?: Redis
+): Warp {
+  const LIMIT_OPTS = constants.DEFAULT_LIMIT_OPTS[cacheType];
+  if (cacheType === 'redis') {
+    const redisCacheOptions: CacheOptions = {
+      inMemory: true,
+      dbLocation: '', // will be overwritten
+      subLevelSeparator: '|',
+    };
+    const redisSpecificOptions: RedisOptions = client
+      ? {
+          ...LIMIT_OPTS,
+          client,
+        }
+      : {
+          ...LIMIT_OPTS,
+          url: globals.__REDIS_URL__,
+        };
+
+    if (useCache.state)
+      warp = warp.useStateCache(
+        new RedisCache(
+          {
+            ...redisCacheOptions,
+            dbLocation: `${contractTxId}.state`,
+          },
+          redisSpecificOptions
+        )
+      );
+    if (useCache.contract)
+      warp = warp.useContractCache(
+        new RedisCache(
+          {
+            ...redisCacheOptions,
+            dbLocation: `${contractTxId}.contract`,
+          },
+          redisSpecificOptions
+        ),
+        new RedisCache(
+          {
+            ...redisCacheOptions,
+            dbLocation: `${contractTxId}.src`,
+          },
+          redisSpecificOptions
+        )
+      );
+
+    warp = warp.useKVStorageFactory(
+      (contractTxId: string) =>
+        new RedisCache(
+          {
+            ...redisCacheOptions,
+            dbLocation: `${contractTxId}.src`,
+          },
+          redisSpecificOptions
+        )
+    );
+  } else if (cacheType === 'lmdb') {
+    const lmdbCacheOptions: CacheOptions = defaultCacheOptions;
+    const lmdbSpecificOptions: LmdbOptions = LIMIT_OPTS;
+
+    if (useCache.state)
+      warp = warp.useStateCache(
+        new LmdbCache(
+          {
+            ...lmdbCacheOptions,
+            dbLocation: './cache/warp/state',
+          },
+          lmdbSpecificOptions
+        )
+      );
+
+    if (useCache.contract)
+      warp = warp.useContractCache(
+        new LmdbCache(
+          {
+            ...lmdbCacheOptions,
+            dbLocation: './cache/warp/contract',
+          },
+          lmdbSpecificOptions
+        ),
+        new LmdbCache(
+          {
+            ...lmdbCacheOptions,
+            dbLocation: './cache/warp/src',
+          },
+          lmdbSpecificOptions
+        )
+      );
+
+    warp = warp.useKVStorageFactory(
+      (contractTxId: string) =>
+        new LmdbCache({
+          ...defaultCacheOptions,
+          dbLocation: `./cache/warp/kv/lmdb_2/${contractTxId}`,
+        })
+    );
+  }
+
+  return warp;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9709,10 +9709,10 @@ warp-contracts-plugin-snarkjs@^0.1.6:
   dependencies:
     snarkjs "^0.6.10"
 
-warp-contracts-redis@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/warp-contracts-redis/-/warp-contracts-redis-0.2.0.tgz#7ead0b15b889dbe1f945d6d42381d6d0cbe05ba7"
-  integrity sha512-R7dAZRVmgP3bgh58twWGLS5X2kT18Qu/emQPFSz56gPrOif0QL0jjhtpw8y4hNpM4YMxES9pgQggmv2qrTwa4w==
+warp-contracts-redis@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/warp-contracts-redis/-/warp-contracts-redis-0.3.1.tgz#59f30b49952bc12b8a26c1f93067eed1e7477c76"
+  integrity sha512-CGCVWcg5/wfe2AhwcQh6B6RqNDhBooST5/BlMfbd12gDjX9n1CehmttBK7htR8DzmVawc85vHzo0+B2o1EcGlg==
   dependencies:
     ioredis "^5.3.2"
     safe-stable-stringify "^2.4.3"


### PR DESCRIPTION
`remove` used to simply do `KV.put(key, null)`. We have now changed that to `KV.del(key)`. This was waiting for a while because there was a problem in Redis SortKeyCache related to deleting keys, which is fixed now & is upgraded to fixed version in this PR.

Also slight refactor within the tests, moved cache initialization to some other function under utils.