### PR TITLE
added regex check to HTX & force exit to test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
   verbose: true,
   // Warp & Arlocal takes some time to close, so make this 5 secs
   openHandlesTimeout: 5000,
+  forceExit: true,
 };
 
 export default config;

--- a/src/contracts/errors/index.ts
+++ b/src/contracts/errors/index.ts
@@ -1,5 +1,6 @@
 export const KeyExistsError = new ContractError('Key already exists.');
 export const KeyNotExistsError = new ContractError('Key does not exist.');
+export const KeyNotHexadecimalError = new ContractError('Key expected to be hexadecimal.');
 export const CantEvolveError = new ContractError('Evolving is disabled.');
 export const NoVerificationKeyError = new ContractError('No verification key.');
 export const UnknownProtocolError = new ContractError('Unknown protocol.');

--- a/src/contracts/functions/htx.ts
+++ b/src/contracts/functions/htx.ts
@@ -1,5 +1,5 @@
 import type {ContractState} from '../types';
-import {KeyExistsError} from '../errors';
+import {KeyExistsError, KeyNotHexadecimalError} from '../errors';
 import {assertWhitelist, safeGet, verifyAuthProofImmediate} from '../utils';
 import {HTXValueType, PutHTXInput, RemoveHTXInput, UpdateHTXInput} from '../types/htx';
 
@@ -9,6 +9,11 @@ export async function putHTX<State extends ContractState<{whitelists: ['put']; c
   caller: string
 ) {
   assertWhitelist(state, caller, 'put');
+
+  // check hexadecimal
+  if (!/^0x[\da-f]+$/i.test(key)) {
+    throw KeyNotHexadecimalError;
+  }
 
   if ((await SmartWeave.kv.get(key)) !== null) {
     throw KeyExistsError;

--- a/tests/htx.test.ts
+++ b/tests/htx.test.ts
@@ -41,10 +41,13 @@ describe('hash.txid value tests', () => {
     expect(cachedValue.state.verificationKeys.auth).toEqual(verificationKey);
   });
 
+  it('should NOT put a key that is not hexadecimal', async () => {});
+
   it('should allow putting without a proof', async () => {
     const txId = mockBundlr.upload(VALUE);
     const valueHash = '0x' + hashToGroup(JSON.stringify(VALUE)).toString(16);
 
+    console.log(KEY);
     const val: HTXValueType = `${valueHash}.${txId}`;
     await owner.put(KEY, val);
     expect(await owner.get(KEY)).toEqual(val);
@@ -73,8 +76,7 @@ describe('hash.txid value tests', () => {
   });
 
   describe('disabling proofs', () => {
-    const {VALUE, NEXT_VALUE} = createValues<ValueType>();
-    const KEY = 'some-non-bigint-friendly-key';
+    const {VALUE, NEXT_VALUE, KEY} = createValues<ValueType>();
 
     beforeAll(async () => {
       const {cachedValue} = await owner.readState();


### PR DESCRIPTION
- The tests may hang due to unknown reasons (Warp / Arweave / SnarkJS in the background?) so it is better to add a force exit anyways. We had removed this before via a teardown script for the tests.
- Added regex check to HTX contract, where the key is expected to be a hexadecimal. Totally optional though, HTX just an example contract.